### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *.m~
 
 # MATLAB data files (uncomment if you don't want to track data files)
-# *.mat
+*.mat
 
 # MATLAB figures
 *.fig


### PR DESCRIPTION
added *.mat

## Summary by Sourcery

Chores:
- Add '*.mat' to .gitignore to prevent MATLAB binary files from being tracked